### PR TITLE
Adding checkout menu for go command

### DIFF
--- a/linux_mac/.bash_aliases_gicosh
+++ b/linux_mac/.bash_aliases_gicosh
@@ -61,7 +61,23 @@ git_merge_tool() {
 }
 
 git_checkout() {
-	git checkout $@
+  if [ $# -eq 0 ]; then
+    # carrega branches locais em um array
+    mapfile -t _branches < <(git branch --format="%(refname:short)")
+    echo "Select a branch branch:"
+    for i in "${!_branches[@]}"; do
+      printf "%3d) %s\n" $((i+1)) "${_branches[i]}"
+    done
+    read -rp "Choose [1-${#_branches[@]}]: " _choice
+    if [[ $_choice =~ ^[0-9]+$ ]] && [ "$_choice" -ge 1 ] && [ "$_choice" -le "${#_branches[@]}" ]; then
+      git checkout "${_branches[$((_choice-1))]}"
+    else
+      echo "Invalid choice." >&2
+      return 1
+    fi
+  else
+    git checkout "$@"
+  fi
 }
 
 git_pull() {
@@ -79,7 +95,7 @@ git_push() {
     local branch="${2:-$(git rev-parse --abbrev-ref HEAD)}"
 
     if ! git rev-parse --abbrev-ref --symbolic-full-name "${branch}@{u}" > /dev/null 2>&1; then
-        echo -e "\e[33mUpstream não configurado para o branch '\e[34m$branch\e[33m'. Configurando com: \e[34m$remote/$branch\e[33m\e[0m"
+        echo -e "\e[33mUpstream not set for the branch '\e[34m$branch\e[33m'. Setting as: \e[34m$remote/$branch\e[33m\e[0m"
         git push --set-upstream "$remote" "$branch"
     else
         git push
@@ -165,6 +181,7 @@ git_gui() {
 	git gui $@ &
 }
 
+# Now, the aliases
 show_git_aliases() {
     awk -F '=' '/^alias/ {
         alias_name = substr($1, 7);
@@ -180,7 +197,6 @@ show_git_aliases() {
         printf "\033[32m%-20s\033[0m \033[34m%s\033[0m\n", alias_name, command;
     }' ~/.bash_aliases_gicosh
 }
-# Now, the aliases
 alias show.git.aliases=show_git_aliases
 alias ga=git_add
 alias gb=git_branch


### PR DESCRIPTION
When working with a couple of features or while waiting for a revision, you might forget semantic branches (it's ok, I do forget too). So I created a git checkout menu that shows options when you just type `go`.
Then you just need to type a number related to desired branch and type enter. Gicosh will change to that branch.